### PR TITLE
添加功能：保活策略：最近任务列表不显示

### DIFF
--- a/app/src/main/java/com/sealdice/dice/FirstFragment.kt
+++ b/app/src/main/java/com/sealdice/dice/FirstFragment.kt
@@ -35,7 +35,7 @@ import kotlin.system.exitProcess
 /**
  * A simple [Fragment] subclass as the default destination in the navigation.
  */
-class FirstFragment : Fragment() {
+class FirstFragment : Fragment(),SharedPreferences.OnSharedPreferenceChangeListener {
 
     private lateinit var _binding: FragmentFirstBinding
 
@@ -55,6 +55,51 @@ class FirstFragment : Fragment() {
         override fun onServiceDisconnected(name: ComponentName) {
             isBound = false
         }
+    }
+    // Use onCreate function, make settings changes.
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // 注册SharedPreferences监听器
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+    }
+
+    //Pinenutn:(想写英文，发现不会说，我还是中文8）
+    //由于不在最近任务列表显示如果也要放在启动核心之后会出现各种反人类操作，而我又不会改:(
+    //主要还是本人安卓程序开发经验较少……
+    override fun onSharedPreferenceChanged(p0: SharedPreferences?, p1: String?) {
+        if (p0 != null) {
+            //ADD enableExcludeFromRecents
+            if(p0.getBoolean("alive_excluderecents",false)){
+                //不在最近任务列表中显示
+                val am = context?.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+                am.let {
+                    val tasks = it.appTasks
+                    if (!tasks.isNullOrEmpty()) {
+                        Toast.makeText(context,"豹豹已下潜",Toast.LENGTH_SHORT).show();
+                        tasks[0].setExcludeFromRecents(true)
+                    }
+                }
+            }
+            else{
+                //恢复最近任务列表中显示
+                val am = context?.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+                am.let {
+                    val tasks = it.appTasks
+                    if (!tasks.isNullOrEmpty()) {
+                        Toast.makeText(context,"豹豹已上浮",Toast.LENGTH_SHORT).show();
+                        tasks[0].setExcludeFromRecents(false)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // 在Fragment销毁时取消注册SharedPreferences监听器，以防止内存泄漏
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
     }
 
     override fun onCreateView(
@@ -541,4 +586,5 @@ class FirstFragment : Fragment() {
             false
         }
     }
+
 }

--- a/app/src/main/java/com/sealdice/dice/MainActivity.kt
+++ b/app/src/main/java/com/sealdice/dice/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.sealdice.dice
 
+import android.app.ActivityManager
 import android.content.*
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -8,6 +9,7 @@ import android.os.PersistableBundle
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -18,6 +20,8 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import com.sealdice.dice.databinding.ActivityMainBinding
+import com.sealdice.dice.utils.Utils
+import com.sealdice.dice.utils.ViewModelMain
 import com.tencent.smtt.export.external.TbsCoreSettings
 import com.tencent.smtt.sdk.QbSdk
 import kotlinx.coroutines.Dispatchers
@@ -29,7 +33,7 @@ import okhttp3.Request
 import org.json.JSONObject
 
 
-private class PreInitCallbackImpl: QbSdk.PreInitCallback {
+private class PreInitCallbackImpl : QbSdk.PreInitCallback {
     override fun onCoreInitFinished() {
     }
 
@@ -46,6 +50,25 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        //每次都检查是否需要关闭/启动后台
+        if (Utils.getExcludeFromRecents(this)) {
+            val am = this.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            am.let {
+                val tasks = it.appTasks
+                if (!tasks.isNullOrEmpty()) {
+                    tasks[0].setExcludeFromRecents(true)
+                }
+            }
+        } else {
+            //恢复最近任务列表中显示
+            val am = this.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            am.let {
+                val tasks = it.appTasks
+                if (!tasks.isNullOrEmpty()) {
+                    tasks[0].setExcludeFromRecents(false)
+                }
+            }
+        }
         val intentUpdateService = Intent(this, UpdateService::class.java)
         startService(intentUpdateService)
         QbSdk.initX5Environment(this, PreInitCallbackImpl())
@@ -63,9 +86,18 @@ class MainActivity : AppCompatActivity() {
         val navController = findNavController(R.id.nav_host_fragment_content_main)
         appBarConfiguration = AppBarConfiguration(navController.graph)
         setupActionBarWithNavController(navController, appBarConfiguration)
-        if (ContextCompat.checkSelfPermission(this, android.Manifest.permission.INTERNET) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this, arrayOf(android.Manifest.permission.INTERNET),1)
+        if (ContextCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.INTERNET
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(android.Manifest.permission.INTERNET),
+                1
+            )
         }
+
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -77,7 +109,7 @@ class MainActivity : AppCompatActivity() {
     override fun onPostCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
         super.onPostCreate(savedInstanceState, persistentState)
         if (this.packageName != "com.sealdice.dice") {
-            val alertDialogBuilder = AlertDialog.Builder(this,R.style.Theme_Mshell_DialogOverlay)
+            val alertDialogBuilder = AlertDialog.Builder(this, R.style.Theme_Mshell_DialogOverlay)
             alertDialogBuilder.setTitle("提示")
             alertDialogBuilder.setMessage("检测到您正在使用非官方版本或多开软件，可能会导致一些问题，建议您使用官方版本")
             alertDialogBuilder.setPositiveButton("确定") { _: DialogInterface, _: Int -> }
@@ -139,34 +171,37 @@ class MainActivity : AppCompatActivity() {
                         val jsonData = response.body?.string()
                         val jsonObject = jsonData?.let { JSONObject(it) }
                         val latestVersion = jsonObject?.getString("version")
-                        Log.e("--Service--","已经获取了version${latestVersion}")
+                        Log.e("--Service--", "已经获取了version${latestVersion}")
                         // Check if current version is up-to-date
                         val currentVersion = BuildConfig.VERSION_NAME
                         if (latestVersion != currentVersion) {
                             // Show update notification
                             withContext(Dispatchers.Main) {
                                 dialog.cancel()
-                                val alertDialogBuilder = AlertDialog.Builder(self,R.style.Theme_Mshell_DialogOverlay)
+                                val alertDialogBuilder =
+                                    AlertDialog.Builder(self, R.style.Theme_Mshell_DialogOverlay)
                                 alertDialogBuilder.setTitle("提示")
                                 alertDialogBuilder.setMessage("发现更新，点击确定开始下载新版本\n线上版本:${latestVersion}\n本地版本:${currentVersion}")
                                 alertDialogBuilder.setPositiveButton("确定") { _: DialogInterface, _: Int ->
-                                    val uri = Uri.parse("https://d.catlevel.com/seal/android/latest")
+                                    val uri =
+                                        Uri.parse("https://d.catlevel.com/seal/android/latest")
                                     val intent = Intent()
                                     intent.action = "android.intent.action.VIEW"
                                     intent.data = uri
                                     startActivity(intent)
                                 }
-                                alertDialogBuilder.setNegativeButton("取消") {_: DialogInterface, _: Int ->}
+                                alertDialogBuilder.setNegativeButton("取消") { _: DialogInterface, _: Int -> }
                                 alertDialogBuilder.create().show()
                             }
                         } else {
-                        // Current version is up-to-date
+                            // Current version is up-to-date
                             withContext(Dispatchers.Main) {
                                 dialog.cancel()
-                                val alertDialogBuilder = AlertDialog.Builder(self,R.style.Theme_Mshell_DialogOverlay)
+                                val alertDialogBuilder =
+                                    AlertDialog.Builder(self, R.style.Theme_Mshell_DialogOverlay)
                                 alertDialogBuilder.setTitle("提示")
                                 alertDialogBuilder.setMessage("当前版本已是最新")
-                                alertDialogBuilder.setPositiveButton("确定") { _: DialogInterface, _: Int ->}
+                                alertDialogBuilder.setPositiveButton("确定") { _: DialogInterface, _: Int -> }
                                 alertDialogBuilder.create().show()
                             }
                         }
@@ -174,13 +209,18 @@ class MainActivity : AppCompatActivity() {
                         e.printStackTrace()
                         withContext(Dispatchers.Main) {
                             dialog.cancel()
-                            val alertDialogBuilder = AlertDialog.Builder(self,R.style.Theme_Mshell_DialogOverlay)
+                            val alertDialogBuilder =
+                                AlertDialog.Builder(self, R.style.Theme_Mshell_DialogOverlay)
                             alertDialogBuilder.setTitle("提示")
                             alertDialogBuilder.setMessage("检查更新时出现错误，可能是网络问题，请稍后重试")
-                            alertDialogBuilder.setNegativeButton("查看错误信息") {_: DialogInterface, _: Int ->
-                                AlertDialog.Builder(self,R.style.Theme_Mshell_DialogOverlay).setTitle("错误信息").setMessage("错误信息:\n${e.localizedMessage}\nStackTrace:\n${e.stackTraceToString()}").setPositiveButton("确定") { _: DialogInterface, _: Int ->}.create().show()
+                            alertDialogBuilder.setNegativeButton("查看错误信息") { _: DialogInterface, _: Int ->
+                                AlertDialog.Builder(self, R.style.Theme_Mshell_DialogOverlay)
+                                    .setTitle("错误信息")
+                                    .setMessage("错误信息:\n${e.localizedMessage}\nStackTrace:\n${e.stackTraceToString()}")
+                                    .setPositiveButton("确定") { _: DialogInterface, _: Int -> }
+                                    .create().show()
                             }
-                            alertDialogBuilder.setPositiveButton("确定") { _: DialogInterface, _: Int ->}
+                            alertDialogBuilder.setPositiveButton("确定") { _: DialogInterface, _: Int -> }
                             alertDialogBuilder.create().show()
                         }
                     }

--- a/app/src/main/java/com/sealdice/dice/utils/Utils.kt
+++ b/app/src/main/java/com/sealdice/dice/utils/Utils.kt
@@ -10,11 +10,25 @@ import android.provider.Settings
 import android.text.TextUtils
 import android.util.Log
 import android.widget.Toast
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import com.sealdice.dice.MediaService
 import java.util.ArrayList
 
 
 object Utils {
     const val REQUEST_FLOAT_CODE=1001
+    /**
+    * 用于检查是否需要消除后台任务的变量
+    */
+    fun getExcludeFromRecents(context: Context):Boolean{
+        val sharedPreferences = context.let { PreferenceManager.getDefaultSharedPreferences(it) }
+        if (sharedPreferences != null) {
+            return sharedPreferences.getBoolean("alive_media", false)
+        }
+        return false
+    }
+
     /**
      * 跳转到设置页面申请打开无障碍辅助功能
      */

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -23,6 +23,11 @@
             android:title="保活策略：无声音频"
             android:summary="通过循环播放无声音频进行保活"
             android:defaultValue="false" />
+        <androidx.preference.SwitchPreferenceCompat
+            android:key="alive_excluderecents"
+            android:title="保活策略：最近任务列表不显示"
+            android:summary="豹豹通过在最近任务列表里潜水，有效避免某些系统划后台强行扬了可爱的豹豹的人间惨剧。"
+            android:defaultValue="false" />
 
     </androidx.preference.PreferenceCategory>
 


### PR DESCRIPTION
本人安卓开发很少，代码写的烂……大概就是加了一个最近任务列表不显示的功能。有效防止被MIUI一类的杀掉后台导致核心掉。只能用在安卓5还是6往上，记不清了……